### PR TITLE
Fix #1: redirect after successful pick submission

### DIFF
--- a/frontend/app/leaderboard/page.js
+++ b/frontend/app/leaderboard/page.js
@@ -17,6 +17,8 @@ function LeaderboardPageContent() {
   const searchLeagueId = searchParams.get("leagueId") || "";
   const searchBoardMode = searchParams.get("boardMode") || "racePoints";
   const searchViewMode = searchParams.get("viewMode") || "summary";
+  const submitted = searchParams.get("submitted") === "1";
+  const submittedRace = searchParams.get("submittedRace") || "your race";
 
   const [year, setYear] = useState(searchYear);
   const [boardMode, setBoardMode] = useState(searchBoardMode);
@@ -131,6 +133,13 @@ function LeaderboardPageContent() {
   return (
     <div className="pb-24">
       <Header title="Season Leaderboard" subtitle={`Year ${year} with race-by-race points`} />
+
+      {submitted ? (
+        <section className="card mb-3 border border-emerald-300/30 bg-emerald-500/10 p-3">
+          <p className="text-sm font-semibold text-emerald-100">Predictions submitted for {submittedRace}.</p>
+          <p className="mt-1 text-xs text-emerald-200">Your updated standings will appear here after results are scored.</p>
+        </section>
+      ) : null}
 
       <section className="card mb-3 p-3">
         <div className="grid gap-3 md:grid-cols-2">

--- a/frontend/app/races/[raceId]/picks/page.js
+++ b/frontend/app/races/[raceId]/picks/page.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import Header from "../../../../components/Header";
 import { apiFetch } from "../../../../lib/api";
 
@@ -257,6 +257,7 @@ function getInputMeta(category, race, values) {
 
 export default function PicksPage() {
   const { raceId } = useParams();
+  const router = useRouter();
   const [race, setRace] = useState(null);
   const [values, setValues] = useState({});
   const [savedValues, setSavedValues] = useState({});
@@ -382,6 +383,15 @@ export default function PicksPage() {
       setSaveStatus(res.status || (mode === "submit" ? "submitted" : "draft"));
       setSubmittedAt(res.submittedAt || null);
       setMessage(mode === "submit" ? "Picks submitted successfully" : "Draft saved successfully");
+      if (mode === "submit") {
+        const params = new URLSearchParams();
+        params.set("submitted", "1");
+        params.set("submittedRace", race.name);
+        params.set("year", String(new Date(race.race_date).getUTCFullYear()));
+        if (selectedLeagueId) params.set("leagueId", selectedLeagueId);
+        router.push(`/leaderboard?${params.toString()}`);
+        return;
+      }
     } catch (err) {
       setUpdatedLeagueNames([]);
       setMessage(err.message);


### PR DESCRIPTION
## Summary
- redirect players to the leaderboard - store the admin-entered deadline as a manual fallback
- derive the active race deadline from the earliest enabled prediction session when schedule data exists
- recompute deadline_at whene/- derive the active race deadline from the earliest enri- recompute deadline_at when admin prediction categories are saved or a race is edited

## Validation
-lo
## Validation
- cd backend && npm run validate