### PR TITLE
Fix #10: add forgot and reset password flow

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -22,6 +22,15 @@ const loginSchema = z.object({
   password: z.string().min(8)
 });
 
+const forgotPasswordSchema = z.object({
+  email: z.string().email()
+});
+
+const resetPasswordSchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8)
+});
+
 function signToken(user) {
   const id = user.id || user._id || (user._id && user._id.toString());
   return jwt.sign(
@@ -142,10 +151,49 @@ router.post("/verify-email/resend", async (req, res) => {
   });
 });
 
-router.post("/password-reset", async (_req, res) => {
+router.post("/forgot-password", async (req, res) => {
+  const parsed = forgotPasswordSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const email = String(parsed.data.email).trim().toLowerCase();
+  await connectMongo();
+  const found = await User.findOne({ email }).exec();
+
+  if (!found || !found.email_verified_at) {
+    return res.json({ message: "If that account exists, a password reset link has been prepared." });
+  }
+
+  const reset = createVerificationTokenFields();
+  found.password_reset_token_hash = reset.tokenHash;
+  found.password_reset_expires_at = new Date(Date.now() + 60 * 60 * 1000);
+  await found.save();
+
   return res.json({
-    message: "Password reset endpoint placeholder. Integrate with email provider in production."
+    message: "Password reset link prepared.",
+    resetPreviewUrl: buildDebugPreviewUrl("/reset-password", reset.rawToken)
   });
+});
+
+router.post("/reset-password", async (req, res) => {
+  const parsed = resetPasswordSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  await connectMongo();
+  const found = await User.findOne({ password_reset_token_hash: hashToken(parsed.data.token) }).exec();
+  if (!found || !found.password_reset_expires_at || found.password_reset_expires_at.getTime() < Date.now()) {
+    return res.status(400).json({ error: "Password reset link is invalid or expired" });
+  }
+
+  found.password_hash = await bcrypt.hash(parsed.data.password, 10);
+  found.password_reset_token_hash = null;
+  found.password_reset_expires_at = null;
+  await found.save();
+
+  return res.json({ message: "Password updated. You can now log in." });
 });
 
 export default router;

--- a/frontend/app/(auth)/login/page.js
+++ b/frontend/app/(auth)/login/page.js
@@ -48,6 +48,9 @@ export default function LoginPage() {
         />
         {error ? <p className="text-sm text-red-300">{error}</p> : null}
         <button className="tap w-full rounded-xl bg-accent-red font-bold text-white">Login</button>
+        <Link href="/forgot-password" className="block text-center text-sm text-accent-cyan">
+          Forgot your password?
+        </Link>
         <Link href="/verify-email" className="block text-center text-sm text-accent-cyan">
           Need to verify your email?
         </Link>

--- a/frontend/app/forgot-password/page.js
+++ b/frontend/app/forgot-password/page.js
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import Header from "../../components/Header";
+import { publicApiFetch } from "../../lib/api";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [previewUrl, setPreviewUrl] = useState("");
+
+  async function submit(e) {
+    e.preventDefault();
+    setError("");
+    setPreviewUrl("");
+
+    try {
+      const res = await publicApiFetch("/auth/forgot-password", {
+        method: "POST",
+        body: JSON.stringify({ email })
+      });
+      setMessage(res.message);
+      setPreviewUrl(res.resetPreviewUrl || "");
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="pb-24">
+      <Header title="Forgot Password" subtitle="Request a password reset link" />
+      <form onSubmit={submit} className="card space-y-4 p-5">
+        <input
+          className="tap w-full rounded-xl border border-white/30 bg-white/10 px-3 text-white"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        {message ? <p className="text-sm text-emerald-200">{message}</p> : null}
+        {error ? <p className="text-sm text-red-300">{error}</p> : null}
+        {previewUrl ? (
+          <Link href={previewUrl} className="block text-center text-sm text-accent-cyan underline">
+            Open reset preview
+          </Link>
+        ) : null}
+        <button className="tap w-full rounded-xl bg-accent-red font-bold text-white">Send Reset Link</button>
+        <Link href="/login" className="block text-center text-sm text-accent-cyan">
+          Back to login
+        </Link>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/reset-password/page.js
+++ b/frontend/app/reset-password/page.js
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Header from "../../components/Header";
+import { publicApiFetch } from "../../lib/api";
+
+function ResetPasswordPageContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") || "";
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  async function submit(e) {
+    e.preventDefault();
+    setError("");
+
+    try {
+      const res = await publicApiFetch("/auth/reset-password", {
+        method: "POST",
+        body: JSON.stringify({ token, password })
+      });
+      setMessage(res.message);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div className="pb-24">
+      <Header title="Reset Password" subtitle="Choose a new password" />
+      <form onSubmit={submit} className="card space-y-4 p-5">
+        <input
+          className="tap w-full rounded-xl border border-white/30 bg-white/10 px-3 text-white"
+          type="password"
+          placeholder="New password"
+          minLength={8}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {message ? <p className="text-sm text-emerald-200">{message}</p> : null}
+        {error ? <p className="text-sm text-red-300">{error}</p> : null}
+        <button className="tap w-full rounded-xl bg-accent-red font-bold text-white" disabled={!token}>
+          Reset Password
+        </button>
+        {!token ? <p className="text-sm text-amber-200">Open this page from a valid reset link.</p> : null}
+        <Link href="/login" className="block text-center text-sm text-accent-cyan">
+          Back to login
+        </Link>
+      </form>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={<div className="pb-24"><Header title="Reset Password" subtitle="Loading reset form" /><p className="card p-4 text-sm text-slate-300">Loading reset form...</p></div>}>
+      <ResetPasswordPageContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
Summary: add forgot-password and reset-password endpoints, reset token expiry handling, and forgot/reset password pages plus login entry point. Validation: cd backend && npm run validate; cd frontend && npm run build.